### PR TITLE
Fix caption, fix behavior of embed block, add function related to behavior of enter in title

### DIFF
--- a/src/AlisEditor.vue
+++ b/src/AlisEditor.vue
@@ -55,6 +55,7 @@ interface EditorState {
   isPressedEnter: boolean
   intervalId: any
   beforeBlockSnapshot: string
+  insertInitialPositionTrigger: boolean
 }
 
 interface DeviceKeyDownEventArgument {
@@ -78,7 +79,8 @@ export default Vue.extend({
       active: null,
       isPressedEnter: false,
       intervalId: null,
-      beforeBlockSnapshot: ''
+      beforeBlockSnapshot: '',
+      insertInitialPositionTrigger: this.isPressedEnterInTitle
     }
   },
   props: {
@@ -86,7 +88,8 @@ export default Vue.extend({
       type: Array as () => Block[],
       default: []
     },
-    config: config.configProps
+    config: config.configProps,
+    isPressedEnterInTitle: Boolean
   },
   components: {
     EditorBlock,
@@ -102,6 +105,12 @@ export default Vue.extend({
       const id = findRootIdByBlockId(this.active || '', this.store.state.blocks)
       if (!id) return null
       return findTreeContentById(id, this.store.state.blocks) || null
+    }
+  },
+  watch: {
+    isPressedEnterInTitle: function() {
+      this.appendNewBlockInitialPosition()
+      this.insertInitialPositionTrigger = !(this.insertInitialPositionTrigger)
     }
   },
   methods: {
@@ -338,6 +347,9 @@ export default Vue.extend({
         return
       }
       return this.store.appendBlock(createBlock(type, extend), beforeContent)
+    },
+    appendNewBlockInitialPosition() {
+      return this.store.appendParagraphBlockInitialPosition(createBlock(BlockType.Paragraph, {}))
     }
   }
 })

--- a/src/components/blocks/EmbedBlock.vue
+++ b/src/components/blocks/EmbedBlock.vue
@@ -75,7 +75,6 @@ export default Vue.extend({
         div.appendChild(anchorElement)
 
         return div.innerHTML
-        // return getIframelyEmbedTemplate({ ...result })
       }
 
       if (isTwitterResource) {

--- a/src/components/blocks/EmbedBlock.vue
+++ b/src/components/blocks/EmbedBlock.vue
@@ -32,6 +32,7 @@ export default Vue.extend({
   },
   async mounted() {
     this.html = await this.getEmbedContent(this.block.payload.src)
+    await this.$nextTick()
     ;(window as any).iframely.load()
   },
   methods: {
@@ -74,6 +75,7 @@ export default Vue.extend({
         div.appendChild(anchorElement)
 
         return div.innerHTML
+        // return getIframelyEmbedTemplate({ ...result })
       }
 
       if (isTwitterResource) {

--- a/src/components/blocks/ImageBlock.vue
+++ b/src/components/blocks/ImageBlock.vue
@@ -120,7 +120,7 @@ export default Vue.extend({
     }
   },
   async mounted() {
-    autosize(this.$el.querySelector('.image--caption'))
+    autosize((this as any).$el.querySelector('.image--caption'))
     const { src } = this.block.payload
     if (!src.startsWith('data')) {
       return

--- a/src/components/blocks/ImageBlock.vue
+++ b/src/components/blocks/ImageBlock.vue
@@ -15,15 +15,14 @@
       <span class="image--wrapper">
         <img :src="block.payload.src" class="main-image" /><br />
         <ShadowInput @delete="handleDelete" @addimageuri="handleAddImage" />
-        <input
+        <textarea
           class="image--caption"
           :style="{
             opacity: `${+!isUploading}.0`
           }"
           placeholder="説明文を入力"
           :value="this.block.payload.caption"
-          @input="handleInputCaption"
-        />
+          @input="handleInputCaption"></textarea>
       </span>
       <div class="image-uploading" v-if="isUploading">Uploading...</div>
       <div class="image-toolbar" v-if="!isUploading">
@@ -77,6 +76,7 @@
 <script lang="ts">
 import Vue from 'vue'
 import axios from 'axios'
+import autosize from 'autosize'
 import { ImageBlock } from '../../types/Blocks'
 import { createBlogImageFromDataURI } from '../../utils/createImage'
 import ShadowInput from '../blocks/ShadowInput.vue'
@@ -120,6 +120,7 @@ export default Vue.extend({
     }
   },
   async mounted() {
+    autosize(this.$el.querySelector('.image--caption'))
     const { src } = this.block.payload
     if (!src.startsWith('data')) {
       return

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -49,7 +49,6 @@ class Store<S> {
   }
 
   appendBlock(content: Block, beforeContent: Block) {
-    console.log(beforeContent.id)
     const { blocks } = this.instance.$data
     const beforeId = findRootIdByBlockId(beforeContent.id, blocks)
     const beforeIndex = blocks.findIndex((b: Block) => b.id === beforeId)
@@ -57,6 +56,13 @@ class Store<S> {
       return
     }
     blocks.splice(beforeIndex + 1, 0, content)
+    this.setBlocks([...blocks])
+    return content
+  }
+
+  appendParagraphBlockInitialPosition(content: Block) {
+    const { blocks } = this.instance.$data
+    blocks.splice(0, 0, content)
     this.setBlocks([...blocks])
     return content
   }

--- a/tests/unit/components/blocks/__snapshots__/EditorBlock.spec.ts.snap
+++ b/tests/unit/components/blocks/__snapshots__/EditorBlock.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`EditorBlock.vue renders correctly (preview mode) 1`] = `
 <div data-block-id="123" class="block" preview="true">
-  <div class="wrapper paragraph" articleid="" iframelyapikey="" uploadendpoint="" axiosconfig="[object Object]">
+  <div class="wrapper paragraph" articleid="" iframelyapikey="518401c27d170fda5a9fbc" uploadendpoint="" axiosconfig="[object Object]">
     <div contenteditable="true" class="target paragraph">
       <p>foo</p>
     </div>
@@ -14,7 +14,7 @@ exports[`EditorBlock.vue renders correctly (preview mode) 1`] = `
 
 exports[`EditorBlock.vue renders correctly 1`] = `
 <div data-block-id="123" class="block">
-  <div class="wrapper paragraph" articleid="" iframelyapikey="" uploadendpoint="" axiosconfig="[object Object]">
+  <div class="wrapper paragraph" articleid="" iframelyapikey="518401c27d170fda5a9fbc" uploadendpoint="" axiosconfig="[object Object]">
     <div contenteditable="true" class="target paragraph">
       <p>foo</p>
     </div>

--- a/tests/unit/components/blocks/__snapshots__/EditorBlock.spec.ts.snap
+++ b/tests/unit/components/blocks/__snapshots__/EditorBlock.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`EditorBlock.vue renders correctly (preview mode) 1`] = `
 <div data-block-id="123" class="block" preview="true">
-  <div class="wrapper paragraph" articleid="" iframelyapikey="518401c27d170fda5a9fbc" uploadendpoint="" axiosconfig="[object Object]">
+  <div class="wrapper paragraph" articleid="" iframelyapikey="" uploadendpoint="" axiosconfig="[object Object]">
     <div contenteditable="true" class="target paragraph">
       <p>foo</p>
     </div>
@@ -14,7 +14,7 @@ exports[`EditorBlock.vue renders correctly (preview mode) 1`] = `
 
 exports[`EditorBlock.vue renders correctly 1`] = `
 <div data-block-id="123" class="block">
-  <div class="wrapper paragraph" articleid="" iframelyapikey="518401c27d170fda5a9fbc" uploadendpoint="" axiosconfig="[object Object]">
+  <div class="wrapper paragraph" articleid="" iframelyapikey="" uploadendpoint="" axiosconfig="[object Object]">
     <div contenteditable="true" class="target paragraph">
       <p>foo</p>
     </div>

--- a/tests/unit/components/blocks/__snapshots__/ImageBlock.spec.ts.snap
+++ b/tests/unit/components/blocks/__snapshots__/ImageBlock.spec.ts.snap
@@ -39,10 +39,10 @@ exports[`ImageBlock.vue renders correctly 1`] = `
        
       <shadowinput-stub />
        
-      <input
+      <textarea
         class="image--caption"
         placeholder="説明文を入力"
-        style="opacity: 1;"
+        style="opacity: 1; overflow-x: hidden; word-wrap: break-word; overflow-y: hidden;"
       />
     </span>
      


### PR DESCRIPTION
# 変更、追加箇所
- キャプションがver1のエディタ同様文字が折り返される度に1行自動で追加されるように変更
- インスタ・Twitter・Gistsなどのソースを貼り付けた後にEnterを入力するとiframelyがloadされるように修正
- タイトルでEnterを入力した時に1行目にParagraph Blockを一つ追加する関数を追加